### PR TITLE
Fix to exclude slug field when is_home option is checked on page save

### DIFF
--- a/src/Http/Requests/FormRequest.php
+++ b/src/Http/Requests/FormRequest.php
@@ -14,7 +14,7 @@ class FormRequest extends AbstractFormRequest
             'module' => 'nullable|max:255',
             'template' => 'nullable|max:255',
             'title.*' => 'nullable|max:255',
-            'slug.*' => 'nullable|alpha_dash|max:255|required_with:title.*',
+            'slug.*' => 'nullable|alpha_dash|max:255|exclude_if:is_home,1|required_with:title.*',
             'meta_keywords.*' => 'nullable|max:255',
             'meta_description.*' => 'nullable|max:255',
         ];


### PR DESCRIPTION
When saving Page, slug should be left out if "Is Home" option is selected. 
This merge request fixes that with corrected form request to exclude slug if mention option is present.